### PR TITLE
added fees endpoint

### DIFF
--- a/src/bittrex-client.js
+++ b/src/bittrex-client.js
@@ -407,6 +407,21 @@ class BittrexClient {
   }
 
   /**
+   * @method tradingFees - Get trade fee for the given marketSymbol or get trade fees for each markets when marketSymbol is not provided.
+   * @param {String} marketSymbol - Optional. Example: 'BTC-USD'
+   * @returns {Promise} - {
+    "marketSymbol": "string",
+    "makerRate": "number (double)",
+    "takerRate": "number (double)",
+    }
+  */
+
+  async tradingFees(marketSymbol=''){
+    const results = this.requestAuth('GET',`/account/fees/trading/${marketSymbol}`)
+    return results
+  }
+
+  /**
    * @method getNewDepositAddress - Request a new deposit address for specified currencySymbol. Returns an address object.
    * @param {String} currencySymbol - Required. Example: 'BTC'
    * @returns {Promise} - {


### PR DESCRIPTION
Well... there is a `tradingFees` endpoint and I implemented it.

I thought the `CommissionRatesWithMarket` in addition to the bittrex fees would be slightly different on each of the markets... however, it seems that each of the markets have the same rates.